### PR TITLE
Add AddLineAction functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,24 @@ systemctl status almalinux-autopatch.service
       cwd: "rpms"
 
 ```
+
+##### 1.8 add_line – Add a line
+
+- **Description**: Adds a line to a section within the spec file.
+- **Fields**:
+  - `target`: Path to the “spec” (indicates the spec file).
+  - `section`: Spec file section to target (global, description, build, install, files, etc).
+  - `subpackage`: Optional name of the subpackage to target. If not set, target the main package.
+  - `location`: Location to add content ('top' or 'bottom') to the section.
+  - `content`: Actual content to add (supports multi-lines).
+
+**Example**:
+```yaml
+  - add_line:
+    - target: "spec"
+      section: "install"
+      location: "bottom"
+      content: |
+              # Customized SOURCE550 installation
+              install -p -m 0644 %{SOURCE550} %{buildroot}%{_sysconfdir}/yum.repos.d/
+```


### PR DESCRIPTION
This PR adds functionality to add a line to a spec file. Whilst this functionality existed previously with find/replace - this approach results in yaml that is easier to read and is immune to changes upstream as content is not added based on a match.

The implementation supports adding content to either the 'top' or 'bottom' of spec file sections (description, build, install, files, etc) and also has support for the "global" section (top of file).

Modification of sections within subpackages is also supported when the optional `subpackage` parameter is defined.
