### PR TITLE
delete_line sometimes replaces instead of deleting

### DIFF
--- a/src/actions_handler.py
+++ b/src/actions_handler.py
@@ -75,12 +75,13 @@ def process_lines(file_path: Path, target: str, find_lines:list[str], replace_li
                     for _ in range(count_in_line):
                         if entry_count != -1 and counter >= entry_count:
                             break
-                        if not replace_lines and line.strip() == find_lines[0]:
-                            del file[i]
-                            change_made = True
-                            logger.debug(f"Deleted line '{find_lines[0]}' at line {i+1}")
-                            i -= 1
-                            break
+                        if not replace_lines:
+                            if line.strip() == find_lines[0]:
+                                del file[i]
+                                change_made = True
+                                logger.debug(f"Deleted line '{find_lines[0]}' at line {i+1}")
+                                i -= 1
+                                break
                         else:
                             file[i] = file[i].replace(find_lines[0], "\n".join(replace_lines) if replace_lines else "", 1)
                             change_made = True

--- a/tests/configs/redhat-release/autopatch/redhat-release.yaml
+++ b/tests/configs/redhat-release/autopatch/redhat-release.yaml
@@ -1,0 +1,5 @@
+actions:
+  - delete_line:
+    - target: "spec"
+      lines:
+        - "%setup -q -n redhat-release-%{base_release_version} -T -D -a 4"

--- a/tests/configs/redhat-release/expected
+++ b/tests/configs/redhat-release/expected
@@ -1,0 +1,22 @@
+Name: redhat-release
+Version: 1.0
+Release: 1%{?dist}
+Summary: Test package for setup line deletion
+License: GPLv3+
+Source0: %{name}-%{version}.tar.gz
+
+%description
+This is a test package for testing specific line deletion
+
+%prep
+%setup -q -n redhat-release-%{base_release_version} -T -D -a 400
+
+%build
+
+%install
+
+%files
+
+%changelog
+* Mon May 09 2025 Ben Morrice <ben.morrice@cern.ch> - 1.0-1
+- Initial package

--- a/tests/configs/redhat-release/expected
+++ b/tests/configs/redhat-release/expected
@@ -1,7 +1,7 @@
 Name: redhat-release
 Version: 1.0
 Release: 1%{?dist}
-Summary: Test package for setup line deletion
+Summary: Test package for line deletion matching
 License: GPLv3+
 Source0: %{name}-%{version}.tar.gz
 

--- a/tests/configs/redhat-release/redhat-release.spec
+++ b/tests/configs/redhat-release/redhat-release.spec
@@ -1,0 +1,23 @@
+Name: redhat-release
+Version: 1.0
+Release: 1%{?dist}
+Summary: Test package for line deletion matching
+License: GPLv3+
+Source0: %{name}-%{version}.tar.gz
+
+%description
+This is a test package for testing specific line deletion
+
+%prep
+%setup -q -n redhat-release-%{base_release_version} -T -D -a 4
+%setup -q -n redhat-release-%{base_release_version} -T -D -a 400
+
+%build
+
+%install
+
+%files
+
+%changelog
+* Mon May 09 2025 Ben Morrice <ben.morrice@cern.ch> - 1.0-1
+- Initial package


### PR DESCRIPTION
This merge request fixes the logic used in `process_lines`, ensuring that lines are only deleted or replaced when they should be.

The previous code caused issues where the fallback `else:` block could unintentionally execute even when replace_lines was false but line.strip() did not match exactly. As a result, non-matching lines were sometimes replaced, instead of being skipped entirely.

I have also included a new test to cover this logic where previously a deletion configuration was actually being catergorised as a replace.