### PR TITLE
Provide a .spec file to build RPM packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+SPECFILE            = $(shell find -maxdepth 1 -type f -name *.spec)
+SPECFILE_NAME       = $(shell awk '$$1 == "Name:"     { print $$2 }' $(SPECFILE) )
+SPECFILE_VERSION    = $(shell awk '$$1 == "Version:"  { print $$2 }' $(SPECFILE) )
+SPECFILE_RELEASE    = $(shell awk '$$1 == "Release:"  { print $$2 }' $(SPECFILE) )
+TARFILE             = $(SPECFILE_NAME)-$(SPECFILE_VERSION).tar.gz
+DIST               ?= $(shell rpm --eval %{dist})
+
+sources:
+	tar -zcf $(TARFILE) --exclude-vcs --transform 's,^,$(SPECFILE_NAME)-$(SPECFILE_VERSION)/,' ansible src tests LICENSE README.md conf_example.yaml *py
+
+clean:
+	rm -rf build/ $(TARFILE)
+
+srpm: sources
+	rpmbuild -bs --define 'dist $(DIST)' --define "_topdir $(PWD)/build" --define '_sourcedir $(PWD)' $(SPECFILE)
+
+rpm: sources
+	rpmbuild -bb --define 'dist $(DIST)' --define "_topdir $(PWD)/build" --define '_sourcedir $(PWD)' $(SPECFILE)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ After deployment, verify that the service is running properly:
 systemctl status almalinux-autopatch.service
 ```
 
+## RPM packaging
+
+A `Makefile` is provided to faciliate building both a source and binary RPM via `make srpm` or `make rpm`
+
+The `autopatch.spec` file generates a metapackage with several sub packages
+
+- Core functionality is provided by the `autopatch-core` sub package
+  - A helper script `autopatch_standalone.py` is deployed in `%{bindir}/autopatch`
+- Other features are broken out into several other sub packages (`ansible, `git`, `slack`, `web`)
+
+#### Notes
+- The dependency `python3-slackclient' is required for `autopatch-slack`, though this is not currently packaged in EPEL9
+- The dependency `python3-immudb-wrapper` is required for `autopatch-git` which is yet to be packaged (as well as the upstream python3-immudb)
 
 ## Configuration File Format
 

--- a/autopatch.spec
+++ b/autopatch.spec
@@ -1,0 +1,137 @@
+# %{name} is a metapackage that will install all subpackages
+# %{name}-core provides the base functionality
+# other feature sets are split out to separate sub packages
+Name:           autopatch
+Version:        1.0.0
+Release:        1%{?dist}
+Summary:        Tool for autopatching source content for debranding/modification
+License:        GPLv3+
+URL:            https://github.com/almalinux/autopatch-tool
+Source0:        %{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+Requires:       %{name}-core = %{version}-%{release}
+Requires:       %{name}-git = %{version}-%{release}
+Requires:       %{name}-slack = %{version}-%{release}
+Requires:       %{name}-web = %{version}-%{release}
+Requires:       %{name}-ansible = %{version}-%{release}
+
+%description
+A tool to automatically patch upstream content for use downstream
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+# Ansible stuff
+mkdir -p %{buildroot}%{_datadir}/ansible/%{name}
+cp -r ansible/* %{buildroot}%{_datadir}/ansible/%{name}/
+
+# Empty file list for the %{name} metapackage, but we still need to define it
+%files
+
+%package core
+Summary:        Core components of the autopatch tool
+Requires:       python3
+Requires:       python3-pyyaml
+
+%description core
+Core components of the autopatch tool
+
+%files core
+%doc README.md
+%license LICENSE
+%dir %{python3_sitelib}/%{name}/
+%dir %{python3_sitelib}/%{name}/tools/
+%{python3_sitelib}/autopatch_standalone.py
+%{python3_sitelib}/validate_config.py
+%{python3_sitelib}/%{name}/tools/__init__.py
+%{python3_sitelib}/%{name}/tools/logger.py
+%{python3_sitelib}/%{name}/tools/rpm.py
+%{python3_sitelib}/%{name}/tools/tools.py
+%{python3_sitelib}/%{name}/actions_handler.py
+%{python3_sitelib}/%{name}-%{version}-py*.egg-info/
+%{python3_sitelib}/__pycache__/autopatch_standalone.cpython*.pyc
+%{python3_sitelib}/__pycache__/validate_config.cpython*.pyc
+%{python3_sitelib}/%{name}/tools/__pycache__/__init__.cpython*.pyc
+%{python3_sitelib}/%{name}/__pycache__/actions_handler.cpython*.pyc
+%{python3_sitelib}/%{name}/tools/__pycache__/logger.cpython*.pyc
+%{python3_sitelib}/%{name}/tools/__pycache__/rpm.cpython*.pyc
+%{python3_sitelib}/%{name}/tools/__pycache__/tools.cpython*.pyc
+%{_bindir}/autopatch
+%{_bindir}/autopatch_validate_config
+
+
+%package git
+Summary:        Git module for the autopatch tool
+Requires:       %{name}-core = %{version}-%{release}
+Requires:       python3
+Requires:       python3-requests
+Requires:       git
+# python3-immudb-wrapper needs to be packaged (as well as the upstream python3-immudb)
+Requires:       python3-immudb-wrapper
+
+%description git
+Git support for the autopatch tool
+
+%files git
+%{python3_sitelib}/%{name}/tools/git.py
+%{python3_sitelib}/%{name}/tools/__pycache__/git.cpython*.pyc
+%{python3_sitelib}/%{name}/debranding.py
+%{python3_sitelib}/%{name}/__pycache__/debranding.cpython*.pyc
+%{python3_sitelib}/package_patching.py
+%{python3_sitelib}/__pycache__/package_patching.cpython*
+%{_bindir}/autopatch_package_patching
+
+%package slack
+Summary:        Slack module for the autopatch tool
+Requires:       %{name}-core = %{version}-%{release}
+Requires:       python3
+# python3-slackclient exists in Fedora, but not currently in EPEL9
+Requires:       python3-slackclient
+
+%description slack
+Slack notification module for the autopatch tool
+
+%files slack
+%{python3_sitelib}/%{name}/tools/slack.py
+%{python3_sitelib}/%{name}/tools/__pycache__/slack.cpython*.pyc
+
+%package web
+Summary:        Web interface for the autopatch tool
+Requires:       %{name}-core = %{version}-%{release}
+Requires:       python3
+Requires:       python3-flask
+Requires:       python3-werkzeug
+
+%description web
+Web interface for the autopatch tool
+
+%files web
+%{python3_sitelib}/%{name}/webserv.py
+%{python3_sitelib}/%{name}/tools/webserv_tools.py
+%{python3_sitelib}/%{name}/tools/__pycache__/webserv_tools.cpython*.pyc
+%{python3_sitelib}/%{name}/__pycache__/webserv.cpython*.pyc
+
+%package ansible
+Summary: Ansible playbooks for %{name}
+Requires: %{name}-core = %{version}-%{release}
+Requires: ansible-core
+
+%description ansible
+Ansible playbooks for automating %{name} deployment and configuration
+
+%files ansible
+%{_datadir}/ansible/autopatch/
+
+%changelog
+* Wed May 07 2025 Ben Morrice <ben.morrice@cern.ch> - 1.0.0-1
+- initial release
+- code is split out through subpackages (a metapackage is also provided)
+- autopatch_standalone.py provided as %{bindir}/autopatch

--- a/autopatch.spec
+++ b/autopatch.spec
@@ -106,6 +106,8 @@ Slack notification module for the autopatch tool
 %package web
 Summary:        Web interface for the autopatch tool
 Requires:       %{name}-core = %{version}-%{release}
+Requires:       autopatch-git
+Requires:       autopatch-slack
 Requires:       python3
 Requires:       python3-flask
 Requires:       python3-werkzeug

--- a/autopatch.spec
+++ b/autopatch.spec
@@ -1,6 +1,3 @@
-# %{name} is a metapackage that will install all subpackages
-# %{name}-core provides the base functionality
-# other feature sets are split out to separate sub packages
 Name:           autopatch
 Version:        1.0.0
 Release:        1%{?dist}
@@ -12,9 +9,12 @@ BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 Requires:       %{name}-core = %{version}-%{release}
-Requires:       %{name}-git = %{version}-%{release}
-Requires:       %{name}-slack = %{version}-%{release}
-Requires:       %{name}-web = %{version}-%{release}
+Requires:       git
+Requires:       python3-flask
+Requires:       python3-immudb_wrapper
+Requires:       python3-requests
+Requires:       python3-slackclient
+Requires:       python3-werkzeug
 
 %description
 A tool to automatically patch upstream content for use downstream
@@ -28,8 +28,23 @@ A tool to automatically patch upstream content for use downstream
 %install
 %py3_install
 
-# Empty file list for the %{name} metapackage, but we still need to define it
 %files
+# git
+%{python3_sitelib}/%{name}/tools/git.py
+%{python3_sitelib}/%{name}/tools/__pycache__/git.cpython*.pyc
+%{python3_sitelib}/%{name}/debranding.py
+%{python3_sitelib}/%{name}/__pycache__/debranding.cpython*.pyc
+%{python3_sitelib}/package_patching.py
+%{python3_sitelib}/__pycache__/package_patching.cpython*
+%{_bindir}/autopatch_package_patching
+# slack
+%{python3_sitelib}/%{name}/tools/slack.py
+%{python3_sitelib}/%{name}/tools/__pycache__/slack.cpython*.pyc
+# web
+%{python3_sitelib}/%{name}/webserv.py
+%{python3_sitelib}/%{name}/tools/webserv_tools.py
+%{python3_sitelib}/%{name}/tools/__pycache__/webserv_tools.cpython*.pyc
+%{python3_sitelib}/%{name}/__pycache__/webserv.cpython*.pyc
 
 %package core
 Summary:        Core components of the autopatch tool
@@ -62,62 +77,8 @@ Core components of the autopatch tool
 %{_bindir}/autopatch
 %{_bindir}/autopatch_validate_config
 
-
-%package git
-Summary:        Git module for the autopatch tool
-Requires:       %{name}-core = %{version}-%{release}
-Requires:       python3
-Requires:       python3-requests
-Requires:       git
-# python3-immudb-wrapper needs to be packaged (as well as the upstream python3-immudb)
-Requires:       python3-immudb-wrapper
-
-%description git
-Git support for the autopatch tool
-
-%files git
-%{python3_sitelib}/%{name}/tools/git.py
-%{python3_sitelib}/%{name}/tools/__pycache__/git.cpython*.pyc
-%{python3_sitelib}/%{name}/debranding.py
-%{python3_sitelib}/%{name}/__pycache__/debranding.cpython*.pyc
-%{python3_sitelib}/package_patching.py
-%{python3_sitelib}/__pycache__/package_patching.cpython*
-%{_bindir}/autopatch_package_patching
-
-%package slack
-Summary:        Slack module for the autopatch tool
-Requires:       %{name}-core = %{version}-%{release}
-Requires:       python3
-# python3-slackclient exists in Fedora, but not currently in EPEL9
-Requires:       python3-slackclient
-
-%description slack
-Slack notification module for the autopatch tool
-
-%files slack
-%{python3_sitelib}/%{name}/tools/slack.py
-%{python3_sitelib}/%{name}/tools/__pycache__/slack.cpython*.pyc
-
-%package web
-Summary:        Web interface for the autopatch tool
-Requires:       %{name}-core = %{version}-%{release}
-Requires:       %{name}-git = %{version}-%{release}
-Requires:       %{name}-slack = %{version}-%{release}
-Requires:       python3
-Requires:       python3-flask
-Requires:       python3-werkzeug
-
-%description web
-Web interface for the autopatch tool
-
-%files web
-%{python3_sitelib}/%{name}/webserv.py
-%{python3_sitelib}/%{name}/tools/webserv_tools.py
-%{python3_sitelib}/%{name}/tools/__pycache__/webserv_tools.cpython*.pyc
-%{python3_sitelib}/%{name}/__pycache__/webserv.cpython*.pyc
-
 %changelog
 * Wed May 07 2025 Ben Morrice <ben.morrice@cern.ch> - 1.0.0-1
 - initial release
-- code is split out through subpackages (a metapackage is also provided)
+- autopatch-core subpackage exists for a minimum install
 - autopatch_standalone.py provided as %{bindir}/autopatch

--- a/autopatch.spec
+++ b/autopatch.spec
@@ -101,8 +101,8 @@ Slack notification module for the autopatch tool
 %package web
 Summary:        Web interface for the autopatch tool
 Requires:       %{name}-core = %{version}-%{release}
-Requires:       autopatch-git
-Requires:       autopatch-slack
+Requires:       %{name}-git = %{version}-%{release}
+Requires:       %{name}-slack = %{version}-%{release}
 Requires:       python3
 Requires:       python3-flask
 Requires:       python3-werkzeug

--- a/autopatch.spec
+++ b/autopatch.spec
@@ -15,7 +15,6 @@ Requires:       %{name}-core = %{version}-%{release}
 Requires:       %{name}-git = %{version}-%{release}
 Requires:       %{name}-slack = %{version}-%{release}
 Requires:       %{name}-web = %{version}-%{release}
-Requires:       %{name}-ansible = %{version}-%{release}
 
 %description
 A tool to automatically patch upstream content for use downstream
@@ -28,10 +27,6 @@ A tool to automatically patch upstream content for use downstream
 
 %install
 %py3_install
-
-# Ansible stuff
-mkdir -p %{buildroot}%{_datadir}/ansible/%{name}
-cp -r ansible/* %{buildroot}%{_datadir}/ansible/%{name}/
 
 # Empty file list for the %{name} metapackage, but we still need to define it
 %files
@@ -120,17 +115,6 @@ Web interface for the autopatch tool
 %{python3_sitelib}/%{name}/tools/webserv_tools.py
 %{python3_sitelib}/%{name}/tools/__pycache__/webserv_tools.cpython*.pyc
 %{python3_sitelib}/%{name}/__pycache__/webserv.cpython*.pyc
-
-%package ansible
-Summary: Ansible playbooks for %{name}
-Requires: %{name}-core = %{version}-%{release}
-Requires: ansible-core
-
-%description ansible
-Ansible playbooks for automating %{name} deployment and configuration
-
-%files ansible
-%{_datadir}/ansible/autopatch/
 
 %changelog
 * Wed May 07 2025 Ben Morrice <ben.morrice@cern.ch> - 1.0.0-1

--- a/autopatch_standalone.py
+++ b/autopatch_standalone.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+
+# First try importing via site-packages path, then try directly from "src"
+try:
+    import autopatch.tools.rpm
+    from autopatch.actions_handler import ConfigReader
+except ImportError:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+    import src.tools.rpm
+    from actions_handler import ConfigReader
+
+def main():
+    parser = argparse.ArgumentParser(
+       description="Simple Autopatch invocation script"
+    )
+
+    parser.add_argument(
+        '--config',
+        type=str,
+        help='config file',
+        required=True,
+    )
+    parser.add_argument(
+        '--targetdir',
+        type=str,
+        help='Target directory',
+        required=True,
+    )
+    args = parser.parse_args()
+
+    config = ConfigReader(args.config)
+    config.apply_actions(args.targetdir)
+
+if __name__ == "__main__":
+    main()

--- a/package_patching.py
+++ b/package_patching.py
@@ -1,10 +1,16 @@
+#!/usr/bin/env python3
 import os
 import sys
 from logging import INFO, DEBUG
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 
-from src.tools.logger import logger
-from src.debranding import apply_modifications
+# First try importing via site-packages path, then try directly from "src"
+try:
+    from autopatch.tools.logger import logger
+    from autopatch.debranding import apply_modifications
+except ImportError:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+    from src.tools.logger import logger
+    from src.debranding import apply_modifications
 
 import argparse
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="autopatch",
+    version="1.0.0",
+    description="Tool for autopatching source content for debranding/modification",
+    author="AlmaLinux",
+    author_email="info@almalinux.org",
+    url="https://github.com/almalinux/autopatch-tool",
+    packages=["autopatch", "autopatch.tools"],
+    package_dir={
+        "autopatch": "src",
+        "autopatch.tools": "src/tools",
+    },
+    entry_points={
+        "console_scripts": [
+            "autopatch=autopatch_standalone:main",
+            "autopatch_package_patching=package_patching:main",
+            "autopatch_validate_config=validate_config:main",
+        ],
+    },
+    py_modules=["autopatch_standalone", "package_patching", "validate_config"],
+    python_requires=">=3.6",
+)

--- a/src/debranding.py
+++ b/src/debranding.py
@@ -1,12 +1,14 @@
 import os
 
-from actions_handler import ConfigReader
-from tools.logger import logger
-from tools.git import (
-    GitRepository,
-    GitAlmaLinux,
-    DirectoryManager,
-)
+# First try importing via site-packages path, then try directly from "src"
+try:
+    from autopatch.tools.logger import logger
+    from autopatch.actions_handler import ConfigReader
+    from autopatch.tools.git import GitRepository, GitAlmaLinux, DirectoryManager
+except ImportError:
+    from tools.logger import logger
+    from actions_handler import ConfigReader
+    from tools.git import GitRepository, GitAlmaLinux, DirectoryManager
 
 BRANCH_NOT_MODIFIED = "Branch is not modified"
 PACKAGE_NOT_MODIFIED = "Package is not modified"

--- a/src/tools/git.py
+++ b/src/tools/git.py
@@ -4,11 +4,19 @@ import requests
 from pathlib import Path
 
 
-from tools.logger import logger
-from tools.tools import (
-    run_command,
-    load_cas_credentials,
-)
+# First try importing via site-packages path, then try directly from "src"
+try:
+    from autopatch.tools.logger import logger
+    from autopatch.tools.tools import (
+        run_command,
+        load_cas_credentials,
+    )
+except ImportError:
+    from tools.logger import logger
+    from tools.tools import (
+        run_command,
+        load_cas_credentials,
+    )
 
 ALLOW_NOTARIZATION = os.getenv("ALLOW_NOTARIZATION", "true").lower() == "true"
 if ALLOW_NOTARIZATION:

--- a/src/tools/rpm.py
+++ b/src/tools/rpm.py
@@ -4,8 +4,13 @@ from enum import Enum
 from tempfile import NamedTemporaryFile
 from pathlib import Path
 
-from tools.logger import logger
-from tools.tools import run_command
+# First try importing via site-packages path, then try directly from "src"
+try:
+    from autopatch.tools.logger import logger
+    from autopatch.tools.tools import run_command
+except ImportError:
+    from tools.logger import logger
+    from tools.tools import run_command
 
 rpmspec_definition = {
     "__python3": "/usr/bin/python3",

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -3,7 +3,11 @@ from pathlib import Path
 from typing import Dict
 from yaml import safe_load
 
-from tools.logger import logger
+# First try importing via site-packages path, then try directly from "src"
+try:
+    from autopatch.tools.logger import logger
+except ImportError:
+    from tools.logger import logger
 
 
 def run_command(command, raise_on_failure=True, without_log=False, shell=False, cwd=None):

--- a/src/webserv.py
+++ b/src/webserv.py
@@ -8,18 +8,33 @@ from werkzeug.exceptions import (
     InternalServerError,
 )
 
-from debranding import (
-    apply_modifications,
-    SUCCESS
-)
-from tools.logger import logger
-from tools.webserv_tools import (
-    auth_key_required,
-    jsonify_response,
-    get_name_from_payload,
-    get_branch_from_payload,
-)
-import tools.slack
+# First try importing via site-packages path, then try directly from "src"
+try:
+    from autopatch.tools.logger import logger
+    from autopatch.debranding import (
+        apply_modifications,
+        SUCCESS
+    )
+    from autopatch.tools.webserv_tools import (
+        auth_key_required,
+        jsonify_response,
+        get_name_from_payload,
+        get_branch_from_payload,
+    )
+    import autopatch.tools.slack as tools_slack
+except ImportError:
+    from tools.logger import logger
+    from debranding import (
+        apply_modifications,
+        SUCCESS
+    )
+    from tools.webserv_tools import (
+        auth_key_required,
+        jsonify_response,
+        get_name_from_payload,
+        get_branch_from_payload,
+    )
+    import tools.slack as tools_slack
 
 app = Flask('almalinux-debranding-tool')
 
@@ -63,7 +78,7 @@ def debrand_packages():
             branch,
         )
         if result == SUCCESS:
-            tools.slack.success_message(repo_name, branch)
+            tools_slack.success_message(repo_name, branch)
 
         return jsonify_response(
             result={
@@ -73,7 +88,7 @@ def debrand_packages():
         )
     except Exception as err:
         logger.error(err)
-        tools.slack.failed_message(repo_name, branch, str(err))
+        tools_slack.failed_message(repo_name, branch, str(err))
 
 
 @app.errorhandler(InternalServerError)

--- a/validate_config.py
+++ b/validate_config.py
@@ -1,10 +1,14 @@
+#!/usr/bin/env python3
 import argparse
 import sys
 import os
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
-
-from src.actions_handler import ConfigReader
+# First try importing via site-packages path, then try directly from "src"
+try:
+    from autopatch.actions_handler import ConfigReader
+except ImportError:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+    from src.actions_handler import ConfigReader
 
 def main():
     parser = argparse.ArgumentParser(description="Validate config")


### PR DESCRIPTION
This MR provides basic support for packaging `autopatch` as an RPM via `setup.py`. 
A `Makefile` is also provided to facilitate building `srpm` and `rpm` targets.

The RPM is defined as a metapackage for `autopatch`, with sub packages which have additional functionality split out. For the most basic use-case, the `autopatch-core` package can be used.

For full functionality the packages `autopatch-ansible`, `autopatch-git`, `autopatch-slack` and `autopatch-web` are provided.

In addition a simple `autopatch_standalone.py` script has been provided which can be used without any git or web components (provided via `autopatch-core`) and deployed on the system in `%{bindir}/autopatch`

Notes:
- Currently it's impossible to install `autopatch-git` due to missing dependencies (https://github.com/AlmaLinux/immudb-wrapper and the upstream `immudb-py` client) should be packaged
- `autopatch-slack` requires a slack python module that exists in Fedora, but not currently in EPEL9