### PR TITLE
Add project documentation and rename rhel_version to el_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,233 +1,123 @@
-## Deployment Guide
+# AlmaLinux Autopatch Tool
 
-#### Prerequisites
+Autopatch automates the modifications AlmaLinux applies to
+source packages before rebuilding them: **debranding, AlmaLinux-specific patches,
+and release/changelog bookkeeping**. Instead of editing spec files by hand on
+every upstream update, each package's modifications are described once in a
+declarative `config.yaml` and applied automatically.
 
-Before deploying, ensure the following dependencies and configurations are met:
-
-- Ansible installed on the control node.
-- SSH access to the target server.
-- Required credentials stored securely in `ansible/roles/deploy/vars/main.yml`.
-- Ansible inventory file (`inventory.ini`) with the target server IP and SSH key.
-
-#### Deployment Steps
-
-##### 1. Define Required Variables
-
-Ensure the following variables are set in `ansible/roles/deploy/vars/main.yml`:
-
-```yaml
----
-# CAS credentials for notarization
-deploy_cas_signer_id: "your_signer_id"
-deploy_cas_api_key: "your_api_key"
-deploy_immudb_username: "your_username"
-deploy_immudb_password: "your_password"
-deploy_immudb_database: "your_database"
-deploy_immudb_address: "your_immudb_address"
-
-# Slack credentials to send notifications
-deploy_slack_token: "your_slack_token"
-
-# Git authentication key
-deploy_auth_key: "your_git_auth_key"
-
-# SSH keys for git.almalinux.org
-deploy_ssh_private_key: "your_private_key"
-deploy_ssh_public_key: "your_public_key"
+```
+upstream push (c9)  ──►  webhook  ──►  apply config.yaml  ──►  commit + tag + push (a9)
 ```
 
-##### 2. Configure Ansible Inventory
+## Why it exists
 
-Define the target hosts in your Ansible inventory file (e.g., `inventory.ini`):
+AlmaLinux is a downstream rebuild. Every upstream package needs the same kinds of
+mechanical changes — replace the upstream vendor's name, swap certificates, add
+patches, bump the release, write a changelog entry — repeated across hundreds of
+packages on every update. Autopatch turns those changes into version-controlled
+data and runs them automatically, verifiably, and reproducibly.
 
-```ini
-[deploy_servers]
-your-server-ip ansible_user=your_user ansible_ssh_private_key_file=your_key
-```
+## How it works (in brief)
 
-##### 3. Running the Deployment
+Autopatch operates on two git repos per package on `git.almalinux.org`:
 
-Execute the deployment playbook with:
+- **`autopatch/<pkg>`** — human-authored config repo: `config.yaml` + `files/` +
+  `scripts/`. Branches are AlmaLinux branches (`a8`, `a9`, `a10s`, …).
+- **`rpms/<pkg>`** — dist-git: the actual spec file + sources. Holds upstream
+  imports (`c8`, `c9`, …) and the AlmaLinux results (`a8`, `a9`, …).
+
+On each upstream update, Autopatch:
+
+1. maps the upstream branch to the config branch (`c9` → `a9`);
+2. resets the AlmaLinux branch to the fresh upstream import;
+3. applies the package's `config.yaml` (an ordered list of *actions*);
+4. commits (changelog lines become commit messages), tags, pushes, and notarizes.
+
+If a run fails because upstream changed, an optional AI recovery agent can analyze
+the failure and propose a fix as a pull request.
+
+## Quick start
+
+Validate a config:
 
 ```bash
-ansible-playbook -i inventory.ini main.yml
+autopatch_validate_config path/to/config.yaml
+# from a source checkout:
+python validate_config.py path/to/config.yaml
 ```
 
-##### 4. Verification
-
-After deployment, verify that the service is running properly:
+Apply a config to a local package checkout (no git):
 
 ```bash
-systemctl status almalinux-autopatch.service
+autopatch_package_patching --config config.yaml --targetdir ./mypackage
 ```
 
-## RPM packaging
+Run the full debranding workflow for a package (needs git/SSH access):
 
-A `Makefile` is provided to faciliate building both a source and binary RPM via `make srpm` or `make rpm`
-
-The `autopatch.spec` file generates a metapackage with several sub packages
-
-- Core functionality is provided by the `autopatch-core` sub package
-  - A helper script `autopatch_standalone.py` is deployed in `%{bindir}/autopatch`
-- Other features are broken out into several other sub packages (`ansible, `git`, `slack`, `web`)
-
-#### Notes
-- The dependency `python3-slackclient' is required for `autopatch-slack`, though this is not currently packaged in EPEL9
-- The dependency `python3-immudb-wrapper` is required for `autopatch-git` which is yet to be packaged (as well as the upstream python3-immudb)
-
-## Configuration File Format
-
-#### 1. actions (Main Block)
-
-##### 1.1 replace – String Replacement
-
-- **Description**: Replaces a specified strings with anothers.
-- **Fields**:
-  - `target`: Path to the file or “spec” (indicates the spec file). Glob patterns are supported.
-  - `find`: String to search for (supports multi-lines, mutually exclusive to `rfind`).
-  - `rfind`: regex string to search for (supports multi-lines, mutually exclusive to `find`).
-  - `replace`: String to replace with (supports multi-lines).
-  - `count`: Number of replacements (default is -1, which replaces all occurrences).
-
-**Example**:
-```yaml
-  - replace:
-    - target: "*.conf"
-      find: "RHEL"
-      replace: "AlmaLinux"
-      count: 1
-    - target: "spec"
-      find: |
-            %if 0%{?rhel}
-            RHEL
-      replace: |
-            %if 0%{?almalinux}
-            AlmaLinux
-    - target: "spec"
-      rfind: "Requires:.*clang.*"
-      replace: "Requires: clang = %{epoch}:%{version}-%{release}"
-      count: 1
+```bash
+autopatch -p <package> -b c9
 ```
 
-##### 1.2 delete_line – Line Deletion
+A minimal `config.yaml` (add one patch, bump release, write changelog):
 
-- **Description**: Deletes specified lines.
-- **Fields**:
-  - `target`: Path to the file or “spec”. Does not support glob patterns.
-  - `lines`:  List of lines to delete (supports multi-lines).
-
-**Example**:
 ```yaml
-  - delete_line:
-    - target: "README.md"
-      lines:
-        - "line1"
-        - |
-            hello world
-            additional line
-```
-
-##### 1.3 modify_release – Release Number Modification
-
-- **Description**: Adds a suffix to the release number.
-- **Fields**:
-  - `suffix`: Suffix to append to the release number.
-  - `enabled`: Enables or disables the modification (default is true).
-
-**Example**:
-```yaml
+actions:
   - modify_release:
-    - suffix: ".mycustom.1"
+    - suffix: ".alma.1"
       enabled: true
-```
-
-##### 1.4 changelog_entry – Adding Changelog Entries
-
-- **Description**: Adds entries to the changelog.
-- **Fields**:
-  - `name`: Author’s name.
-  - `email`: Author’s email.
-  - `line`: Lines to add to the changelog (also used as commit messages).
-
-**Example**:
-```yaml
   - changelog_entry:
-    - name: "eabdullin"
-      email: "eabdullin@almalinux.org"
+    - name: "Author Name"
+      email: "user@almalinux.org"
       line:
-        - "Updated branding to AlmaLinux"
-        - "Fixed a typo in the README"
-```
-
-##### 1.5 add_files – Adding Files
-
-- **Description**: Adds source files or patches.
-- **Fields**:
-  - `type`: File type (patch or source).
-  - `name`: File name. Should be placed in the `files` directory of the autopatch namespace repository.
-  - `number`: Patch/file number or “Latest” (default is “Latest”).
-  - `modify_spec`: Optional boolean to modify the spec file (default is true). If false, only adds the file without modifying the spec.
-  - `insert_almalinux_line`: Optional boolean to insert the AlmaLinux line in the spec file (default is true). If false, does not insert the line.
-**Example**:
-```yaml
+        - "Add fix for ..."
   - add_files:
     - type: "patch"
-      name: "my_patch.patch"
-      number: "Latest"
-      modify_spec: false
-      insert_almalinux_line: false
-    - type: "source"
-      name: "additional_source.tar.gz"
+      name: "1000-fix-description.patch"
       number: 1000
-      modify_spec: false
-      insert_almalinux_line: false
 ```
 
-##### 1.6 delete_files – Deleting Files
+## Documentation
 
-- **Description**: Deletes files from the repository.
-- **Fields**:
-  - `file_name`: File name to delete.
+| Document | What's inside |
+|----------|---------------|
+| [docs/configuration.md](docs/configuration.md) | Complete `config.yaml` reference: the `parameters` block and all eight action types, with fields, examples, ordering rules, and common patterns. |
+| [docs/writing-actions.md](docs/writing-actions.md) | Developer guide: how the action engine works and how to add a new action type, with a worked example and testing instructions. |
+| [docs/deployment.md](docs/deployment.md) | CLI tools, the webhook service, runtime environment variables, Ansible deployment, the AI agent container, and RPM packaging. |
+| [SKILL.md](SKILL.md) | Task-oriented cheat sheet for config authors (real-world debranding/patching patterns). |
+| [conf_example.yaml](conf_example.yaml) | Annotated example config. |
+| [agent/README.md](agent/README.md) | Design of the AI recovery agent (container, orchestrator, data flow). |
 
-**Example**:
-```yaml
-    - delete_files:
-      - file_name: "file1.txt"
-      - file_name: "file2"
-```
-
-##### 1.7. run_custom_scripts - Running Custom Scripts
-
-- **Description**: Executes user-defined scripts to prepare the package before performing other actions (e.g., creating symbolic links).
-- **Fields**: 
-  - `script`: script name. Should be placed in the `scripts` directory of autopatch namespace repository
-  - `cwd`: "rpms" or "autopatch" ('rpms' by default).
-
-**Example**:
-```yaml
-- run_script:
-    - script: "custom_script.sh"
-      cwd: "rpms"
+## Repository layout
 
 ```
+autopatch-tool/
+├── src/                       # core library + web service + agent host side
+│   ├── actions_handler.py     #   config parser + action engine (the core)
+│   ├── debranding.py          #   end-to-end orchestration
+│   ├── webserv.py             #   Flask webhook server
+│   └── tools/                 #   rpm, git, branch, slack, helpers
+├── agent/                     # AI recovery container (Claude Code)
+├── ansible/                   # deployment role
+├── tests/                     # pytest suite + fixture configs
+├── autopatch_standalone.py    # CLI  -> `autopatch`
+├── package_patching.py        # CLI  -> `autopatch_package_patching`
+├── validate_config.py         # CLI  -> `autopatch_validate_config`
+├── autopatch.spec, Makefile   # RPM packaging
+└── conf_example.yaml          # annotated config example
+```
 
-##### 1.8 add_line – Add a line
+## Development
 
-- **Description**: Adds a line to a section within the spec file.
-- **Fields**:
-  - `target`: Path to the “spec” (indicates the spec file).
-  - `section`: Spec file section to target (global, description, build, install, files, etc).
-  - `subpackage`: Optional name of the subpackage to target. If not set, target the main package.
-  - `location`: Location to add content ('top' or 'bottom') to the section.
-  - `content`: Actual content to add (supports multi-lines).
+```bash
+python -m pytest tests/ -v          # run the test suite
+python -m pytest tests/test_actions.py -v   # just the action engine
+```
 
-**Example**:
-```yaml
-  - add_line:
-    - target: "spec"
-      section: "install"
-      location: "bottom"
-      content: |
-              # Customized SOURCE550 installation
-              install -p -m 0644 %{SOURCE550} %{buildroot}%{_sysconfdir}/yum.repos.d/
+See [docs/writing-actions.md](docs/writing-actions.md) for how to extend the
+engine and add fixture-based tests.
+
+## License
+
+GPLv3+. See [LICENSE](LICENSE).
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ description: Create and maintain AlmaLinux autopatch configs for RPM packages. U
 
 # AlmaLinux Autopatch
 
-Autopatch automates modifications to CentOS/RHEL source packages for AlmaLinux rebuilds. Each package gets a git repo under the [autopatch](https://git.almalinux.org/autopatch) namespace with a `config.yaml` that declares spec changes, patches, and branding. The corresponding RPM dist-git sources live under [rpms](https://git.almalinux.org/rpms/).
+Autopatch automates modifications to upstream Enterprise Linux source packages for AlmaLinux rebuilds. Each package gets a git repo under the [autopatch](https://git.almalinux.org/autopatch) namespace with a `config.yaml` that declares spec changes, patches, and branding. The corresponding RPM dist-git sources live under [rpms](https://git.almalinux.org/rpms/).
 
 ## Repository Layout
 
@@ -49,7 +49,7 @@ String replacement in spec or source files. Supports glob patterns in `target`. 
 ```yaml
   - replace:
     - target: "spec"
-      find: "Red Hat Enterprise Linux"
+      find: "Upstream Vendor Linux"      # the upstream distribution's product name
       replace: "AlmaLinux"
       count: 2
     - target: "*.config"
@@ -179,16 +179,16 @@ actions:
 
 ### Debranding package
 
-Replace RHEL references with AlmaLinux throughout the spec.
+Replace upstream vendor references with AlmaLinux throughout the spec.
 
 ```yaml
 actions:
   - replace:
     - target: "spec"
-      find: "Red Hat Enterprise Linux"
+      find: "Upstream Vendor Linux"      # the upstream distribution's product name
       replace: "AlmaLinux"
     - target: "spec"
-      find: "https://bugzilla.redhat.com/"
+      find: "https://bugs.example.com/"  # the upstream bug tracker URL
       replace: "https://bugs.almalinux.org/"
       count: 1
 
@@ -205,14 +205,14 @@ actions:
 
 ### Secure boot / signing
 
-Replace RHEL certificates and signing references.
+Replace upstream certificates and signing references.
 
 ```yaml
   - replace:
     - target: "spec"
       find: |
-            Source10: redhatsecurebootca3.cer
-            Source11: centossecurebootca2.cer
+            Source10: upstreamsecurebootca3.cer
+            Source11: upstreamsecurebootca2.cer
       replace: |
             Source10: almalinuxsecurebootca0.cer
             Source11: almalinuxsecureboot0.cer
@@ -247,15 +247,14 @@ Add RISC-V support by adjusting arch lists and adding patches.
 ## Workflow: Creating a New Autopatch Config
 
 1. **Clone/init the autopatch repo** for the package on the correct branch (`a8`, `a9`, `a10s`, etc.)
-2. **Identify changes needed** by diffing the AlmaLinux dist-git branch against the upstream CentOS import. CentOS branches map to AlmaLinux branches as follows:
+2. **Identify changes needed** by diffing the AlmaLinux dist-git branch against the upstream import. Upstream branches map to AlmaLinux branches as follows:
 
-   | CentOS (upstream) | AlmaLinux |
+   | Upstream | AlmaLinux |
    |---|---|
    | `c8` | `a8` |
    | `c9` | `a9` |
    | `c10` | `a10` |
    | `c10s` | `a10s` |
-   | `c8-stream-rhel8` | `a8-stream-rhel8` |
 
    For example, to see what AlmaLinux changed in a package for EL8:
    ```

--- a/agent/.claude/skills/autopatch-config/SKILL.md
+++ b/agent/.claude/skills/autopatch-config/SKILL.md
@@ -1,6 +1,6 @@
 # AlmaLinux Autopatch Config Format
 
-Autopatch automates modifications to CentOS/RHEL source packages for AlmaLinux rebuilds. Each package gets a git repo under the `autopatch` namespace with a `config.yaml` that declares spec changes, patches, and branding. The corresponding RPM dist-git sources live under `rpms`.
+Autopatch automates modifications to upstream Enterprise Linux source packages for AlmaLinux rebuilds. Each package gets a git repo under the `autopatch` namespace with a `config.yaml` that declares spec changes, patches, and branding. The corresponding RPM dist-git sources live under `rpms`.
 
 ## Repository Layout
 
@@ -42,7 +42,7 @@ String replacement in spec or source files. Supports glob patterns in `target`. 
 ```yaml
   - replace:
     - target: "spec"
-      find: "Red Hat Enterprise Linux"
+      find: "Upstream Vendor Linux"      # the upstream distribution's product name
       replace: "AlmaLinux"
       count: 2
     - target: "spec"

--- a/conf_example.yaml
+++ b/conf_example.yaml
@@ -12,11 +12,11 @@ actions:
   # replace - actions for replacing strings. Specify target (path to the file or "spec" for the spec file).
   - replace:
       - target: "spec"  # the target can be "spec" or a file to which changes are applied (in this case, the file will be searched for). glob patterns are supported.
-        find: "RHEL" # string to be replaced
+        find: "Upstream Vendor Linux" # string to be replaced (e.g. the upstream distribution's product name)
         replace: "AlmaLinux" # string to replace with
         count: 1  # number of replacements, default is -1 (all occurrences)
       - target: "README.md"
-        find: "RHEL"
+        find: "Upstream Vendor Linux"
         replace: "AlmaLinux"
 
   # delete_line - list of lines to delete. 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,429 @@
+# Configuration Reference (`config.yaml`)
+
+This is the complete reference for the Autopatch config file — the declarative
+description of how a package's spec and sources should be modified. It is the
+canonical, expanded version of [`conf_example.yaml`](../conf_example.yaml).
+
+> Looking for a quick task-oriented cheat sheet with real-world patterns?
+> See [`SKILL.md`](../SKILL.md). This document is the exhaustive reference.
+
+## Where the config lives
+
+In the `autopatch/<package>` repo, on the AlmaLinux branch (`a8`, `a9`, `a10s`, …):
+
+```
+<package>/
+├── config.yaml       # required — the default config for this branch
+├── config-*.yaml     # optional — additional configs (need custom_target_branch)
+├── files/            # patches & source files referenced by add_files
+└── scripts/          # shell scripts referenced by run_script
+```
+
+Autopatch processes **every** file in the package directory whose name starts
+with `config` and ends with `.yaml` (see `get_config_files` in
+[`debranding.py`](../src/debranding.py)). Any file other than `config.yaml` must
+set `custom_target_branch` (see below), otherwise the run fails — this prevents
+two configs from silently writing to the same branch.
+
+## Top-level structure
+
+A config has two top-level keys: an optional `parameters:` block and a required
+`actions:` list.
+
+```yaml
+parameters:          # optional — global behavior switches
+  insert_almalinux_line: true
+  # ...
+
+actions:             # required — ordered list of action blocks
+  - <action_type>:
+    - <entry>
+    - <entry>
+  - <action_type>:
+    - <entry>
+```
+
+- `actions` is an **ordered list**. Actions execute top-to-bottom; ordering
+  matters (see [Action ordering](#action-ordering)).
+- Each action block is a single-key mapping (`replace:`, `add_files:`, …) whose
+  value is a **list of entries**. Even a single entry must be a list item (`-`).
+
+## `parameters` — global parameters
+
+All parameters are optional. Defaults are taken from
+[`GlobalParameters`](../src/actions_handler.py).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `insert_almalinux_line` | bool | `true` | Whether `add_files` inserts the `# AlmaLinux Patch/Source` marker block and the `# Applying AlmaLinux …` apply line into the spec. Per-entry `insert_almalinux_line` in `add_files` overrides this. |
+| `custom_target_branch` | str | `""` | Push the result to this branch instead of the auto-derived one. Also selects which branch a non-default `config-*.yaml` targets. |
+| `pre_clean` | bool | `false` | Wipe the package working tree before merging the upstream branch. Use only when the package has file-type conflicts that block a normal merge. |
+| `ignore_version_macros` | bool | `false` | Use the **raw** `Version:` from the spec for the changelog EVR instead of resolving macros via `rpmspec`. |
+| `ignore_release_macros` | bool | `false` | Use the **raw** `Release:` for the changelog EVR instead of resolving macros. |
+| `tag_prefix` | str | `""` | Prefix prepended to the git tag Autopatch creates. |
+| `el_version` | str | auto (`"8"`) | Enterprise Linux major version used when resolving spec macros. Normally derived automatically from the branch name (`c9` → `9`); set it only to override.|
+
+```yaml
+parameters:
+  insert_almalinux_line: true
+  custom_target_branch: "a9-custom"
+  pre_clean: false
+  ignore_version_macros: false
+  ignore_release_macros: false
+  tag_prefix: "my-prefix-"
+```
+
+## Actions
+
+There are eight action types. The table is followed by a detailed section for
+each.
+
+| Action | Purpose | Required keys |
+|--------|---------|---------------|
+| [`replace`](#replace) | Find & replace strings (literal or regex) | `target`, (`find` or `rfind`), `replace` |
+| [`delete_line`](#delete_line) | Delete exact lines/blocks | `target`, `lines` |
+| [`modify_release`](#modify_release) | Append a suffix to `Release:` | `suffix` |
+| [`changelog_entry`](#changelog_entry) | Add a `%changelog` entry (and commit message) | `name`, `email`, `line` |
+| [`add_files`](#add_files) | Add a patch or source file | `type`, `name` |
+| [`delete_files`](#delete_files) | Remove a file (incl. lookaside metadata) | `file_name` |
+| [`run_script`](#run_script) | Run a custom shell script | `script` |
+| [`add_line`](#add_line) | Insert content into a spec section | `target`, `section`, `location`, `content` |
+
+The special `target` value **`"spec"`** means "the package's `.spec` file";
+Autopatch finds the single `*.spec` file automatically (and errors if there are
+zero or more than one).
+
+### `replace`
+
+String replacement in the spec or any source file.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `target` | str | — | `"spec"` or a file path. **Glob patterns are supported** (e.g. `"*.config"`, `"kernel*.config"`). |
+| `find` | str | — | Literal string to search for. Mutually exclusive with `rfind`. Multi-line supported via `|`. |
+| `rfind` | str | — | Regular expression to search for. Mutually exclusive with `find`. |
+| `replace` | str | — | Replacement string. Multi-line supported via `|`. An empty value deletes the match. |
+| `count` | int | `-1` | Number of replacements; `-1` = all occurrences. **Always set it explicitly** for predictability. |
+
+```yaml
+  - replace:
+    - target: "spec"
+      find: "Upstream Vendor Linux"      # the upstream distribution's product name
+      replace: "AlmaLinux"
+      count: 2
+    - target: "*.config"
+      find: "# CONFIG_FOO is not set"
+      replace: "CONFIG_FOO=y"
+      count: 1
+    - target: "spec"
+      rfind: "Requires:.*clang.*"
+      replace: "Requires: clang = %{epoch}:%{version}-%{release}"
+      count: 1
+    - target: "spec"
+      find: |
+            %global vendor_name Upstream Vendor
+            %global vendor_bug https://bugs.example.com/
+      replace: |
+            %global vendor_name AlmaLinux
+            %global vendor_bug https://bugs.almalinux.org/
+```
+
+Notes:
+- In a spec file, processing **stops at `%changelog`** — `replace` never touches
+  the changelog.
+- Comment lines (`#…`) in a spec are skipped unless your `find` itself is a
+  comment.
+- Multi-line `find`/`replace` is matched ignoring leading indentation; the
+  original indentation of the matched block is preserved on the replacement.
+
+### `delete_line`
+
+Delete exact lines or multi-line blocks. **Does not support glob patterns** in
+`target`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `target` | str | `"spec"` or a single file path. |
+| `lines` | list | List of lines/blocks to delete. Each item may be multi-line (`|`). |
+
+```yaml
+  - delete_line:
+    - target: "spec"
+      lines:
+        - "ExcludeArch: ppc64le"
+        - |
+          if [ "$KernelExtension" == "gz" ]; then
+                gzip -f9 $SignImage
+          fi
+```
+
+### `modify_release`
+
+Append a suffix to the `Release:` tag. Prefer this over a `replace` on the
+release line — it works regardless of the upstream release number and handles
+`%autorelease`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `suffix` | str | — | Suffix appended to `Release:` (e.g. `.alma.1`). |
+| `enabled` | bool | `true` | Set `false` to disable without removing the block. |
+
+```yaml
+  - modify_release:
+    - suffix: ".alma.1"
+      enabled: true
+```
+
+- Increment the number (`.alma.2`, `.alma.3`, …) when you make further changes to
+  the same upstream version.
+- If the spec uses `%autorelease`, the suffix is appended to the autorelease
+  final-line template instead of the literal `Release:` value.
+- The combined suffix from all enabled `modify_release` entries is also appended
+  to the git tag.
+
+### `changelog_entry`
+
+Add a `%changelog` entry. The `line` items double as the **git commit messages**
+for the run.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | str | Author name. |
+| `email` | str | Author email. |
+| `line` | list | One or more changelog/commit lines. |
+
+```yaml
+  - changelog_entry:
+    - name: "Andrew Lukoshko"
+      email: "alukoshko@almalinux.org"
+      line:
+        - "fix(nftables): batch ipset elements to avoid O(n^2) insertion cost"
+        - "Resolves: almalinux/almalinux-deploy#186"
+```
+
+- The EVR (epoch-version-release) for the entry header is computed from the spec
+  (resolving macros via `rpmspec`, unless `ignore_*_macros` is set).
+- If the spec uses `%autochangelog`, no literal entry is inserted; instead the
+  first line is prefixed with `AlmaLinux changes:`.
+- Long lines are wrapped at 80 columns.
+- **Always include a `changelog_entry`** — it drives both the spec changelog and
+  the commit message.
+
+### `add_files`
+
+Add a patch or source file to the package. The file **must exist in the config
+repo's `files/` directory**. By default the spec is updated with a
+`PatchNNN:`/`SourceNNN:` line (and, for patches, an apply directive).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | str | — | `"patch"` or `"source"`. |
+| `name` | str | — | File name; must exist under `files/`. |
+| `number` | int or `"Latest"` | `"Latest"` | Patch/Source number, or `"Latest"` to auto-assign the next free number. |
+| `modify_spec` | bool | `true` | If `false`, only copy the file; don't edit the spec (use when you reference it manually via `replace`/`add_line`). |
+| `insert_almalinux_line` | bool | inherits global | Insert the `# AlmaLinux …` marker / apply line. Overrides the global `insert_almalinux_line`. |
+| `no_backup` | bool | `false` | For patches: omit the `-b .<stem>` backup suffix on the apply line. No effect for sources. |
+
+```yaml
+  - add_files:
+    - type: "patch"
+      name: "1000-fix-something.patch"
+      number: 1000
+    - type: "source"
+      name: "almalinux.pem"
+      number: 9000
+    - type: "source"
+      name: "extra-cert.cer"
+      modify_spec: false        # copy only; spec untouched
+```
+
+Conventional numbering:
+
+| Range | Use |
+|-------|-----|
+| `1000+` | AlmaLinux-specific patches |
+| `2000+` | driver / hardware-enablement patches |
+| `9000+` | source files (certs, keys) |
+
+Autopatch detects the patch-apply style used by the spec (classic `%patchN`,
+`%patch -P N`, kernel `ApplyPatch`, `%autosetup`, or a `*.patches` file) and
+inserts the new directive in the matching style and location. If the package
+uses a `SPECS/` + `SOURCES/` layout, added files land in `SOURCES/`.
+
+### `delete_files`
+
+Remove a file from the package. If the file is tracked in dist-git lookaside
+metadata (`.<pkg>.metadata` or `sources`), the corresponding hash line is removed
+too.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `file_name` | str | Name of the file to delete (searched within the package). |
+
+```yaml
+  - delete_files:
+    - file_name: "old-cert.cer"
+    - file_name: "obsolete.patch"
+```
+
+### `run_script`
+
+Run a custom shell script for preparation work the other actions can't express
+(e.g. creating symlinks, generating files). The script must live in the config
+repo's `scripts/` directory.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `script` | str | — | Script file name under `scripts/`. |
+| `cwd` | str | `"rpms"` | Working directory: `"rpms"` (the package/dist-git tree) or `"autopatch"` (the config repo). |
+
+```yaml
+  - run_script:
+    - script: "custom_script.sh"
+      cwd: "rpms"
+```
+
+The script is run with `bash`; a non-zero exit fails the run.
+
+### `add_line`
+
+Insert content into a specific spec section.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `target` | str | — | Must be `"spec"`. |
+| `section` | str | — | Section name: `global`, `description`, `prep`, `build`, `install`, `check`, `files`, `post`, … |
+| `location` | str | — | `"top"` or `"bottom"` of the section. |
+| `content` | str | — | Content to insert (multi-line via `|`). |
+| `subpackage` | str | main package | Target a specific subpackage's section instead of the main package. |
+
+```yaml
+  - add_line:
+    - target: "spec"
+      section: "install"
+      location: "bottom"
+      content: |
+              # Customized SOURCE550 installation
+              install -p -m 0644 %{SOURCE550} %{buildroot}%{_sysconfdir}/yum.repos.d/
+```
+
+- `global` is the implicit pre-`%description` preamble section.
+- For sections that can be tied to a subpackage (`%files`, `%description`,
+  `%pre`, `%post`, …), `subpackage` selects the right one (both `%package foo`
+  and `%package -n foo` forms are understood).
+
+## Action ordering
+
+Because actions run in declaration order, put **mutating-the-existing-spec**
+actions before actions that **add new lines**:
+
+1. `replace`, `delete_line` — edit the upstream spec while its content is still
+   in the original form your `find` strings expect.
+2. `add_files`, `add_line` — append AlmaLinux additions.
+3. `modify_release`, `changelog_entry` — bookkeeping (order between these two
+   doesn't matter; the changelog reads the already-suffixed release).
+
+A common, safe template:
+
+```yaml
+actions:
+  - replace: [ ... ]          # debrand / fix existing content
+  - delete_line: [ ... ]      # remove unwanted lines
+  - add_files: [ ... ]        # add patches / sources
+  - add_line: [ ... ]         # add spec section content
+  - modify_release:
+    - suffix: ".alma.1"
+  - changelog_entry:
+    - name: "..."
+      email: "..."
+      line: [ "..." ]
+```
+
+## Common patterns
+
+### Patch-only (most common)
+
+```yaml
+actions:
+  - modify_release:
+    - suffix: ".alma.1"
+      enabled: true
+  - changelog_entry:
+    - name: "Author Name"
+      email: "user@almalinux.org"
+      line:
+        - "Description of the fix"
+  - add_files:
+    - type: "patch"
+      name: "1000-fix-description.patch"
+      number: 1000
+```
+
+### Debranding
+
+```yaml
+actions:
+  - replace:
+    - target: "spec"
+      find: "Upstream Vendor Linux"        # the upstream distribution's product name
+      replace: "AlmaLinux"
+    - target: "spec"
+      find: "https://bugs.example.com/"    # the upstream bug tracker URL
+      replace: "https://bugs.almalinux.org/"
+      count: 1
+  - modify_release:
+    - suffix: ".alma.1"
+      enabled: true
+  - changelog_entry:
+    - name: "Eduard Abdullin"
+      email: "eabdullin@almalinux.org"
+      line:
+        - "Debrand for AlmaLinux"
+```
+
+### Secure boot / signing certificates
+
+```yaml
+actions:
+  - replace:
+    - target: "spec"
+      find: |
+            Source10: upstreamsecurebootca3.cer
+            Source11: upstreamsecurebootca2.cer
+      replace: |
+            Source10: almalinuxsecurebootca0.cer
+            Source11: almalinuxsecureboot0.cer
+      count: 1
+  - add_files:
+    - type: "source"
+      name: "almalinuxsecurebootca0.cer"
+      modify_spec: false
+    - type: "source"
+      name: "almalinuxsecureboot0.cer"
+      modify_spec: false
+```
+
+## Validate before you commit
+
+```bash
+autopatch_validate_config path/to/config.yaml
+# or, from a source checkout:
+python validate_config.py path/to/config.yaml
+```
+
+This parses and validates the config (keys, types, required fields, mutual
+exclusivity of `find`/`rfind`, etc.) without touching any repo.
+
+## Authoring tips
+
+- **Prefer `modify_release` over `replace`** for the release suffix.
+- **Set `count` explicitly** on `replace` to avoid surprising over-replacement.
+- **Multi-line `find` must match the spec exactly**, including indentation of the
+  first line's interior — Autopatch matches ignoring leading whitespace but
+  preserves it on output.
+- When generating a patch against a tree that already has earlier patches
+  applied, verify it applies with `patch --fuzz=0` (since `%autosetup` uses
+  `--fuzz=0`).
+- An action that matches nothing raises `ActionNotAppliedError` and fails the
+  run — this is intentional. If upstream changed and your `find` no longer
+  matches, update the config (or let the AI agent propose a fix).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,185 @@
+# Deployment & Operations
+
+How to run Autopatch — as CLI tools, as the webhook service, and as a packaged,
+Ansible-deployed system. Also covers RPM packaging and the runtime environment.
+
+## CLI tools
+
+Three console scripts are installed (see [`setup.py`](../setup.py)). From a source
+checkout you can call the underlying modules directly.
+
+### `autopatch` — full debranding workflow
+
+Runs the complete workflow (clone `autopatch/<pkg>` and `rpms/<pkg>`, merge the
+upstream import, apply the config, commit, tag, push, notarize). This is the same
+code path the webhook uses.
+
+```bash
+autopatch -p <package> -b <upstream-branch> [options]
+# from source:
+python autopatch_standalone.py -p <package> -b <upstream-branch> [options]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-p`, `--package` | Package name (required). |
+| `-b`, `--branch` | Upstream branch to apply changes from, e.g. `c9` (required). |
+| `-t`, `--target-branch` | Target/config branch. Default: auto (`c`→`a`). |
+| `--set-custom-tag` | Use a fixed tag instead of the auto-generated one. |
+| `--no-tag` | Don't create a git tag. |
+| `--debug` | Verbose logging. |
+
+> Requires SSH write access to `git.almalinux.org` and (unless disabled) immudb
+> notarization credentials. For local experiments, set `ALLOW_NOTARIZATION=false`.
+
+### `autopatch_package_patching` — apply a config locally
+
+Applies a `config.yaml` to a directory **with no git operations** — useful for
+testing a config against a checked-out spec.
+
+```bash
+autopatch_package_patching --config path/to/config.yaml --targetdir path/to/package
+# from source:
+python package_patching.py --config path/to/config.yaml --targetdir path/to/package
+```
+
+### `autopatch_validate_config` — validate a config
+
+```bash
+autopatch_validate_config path/to/config.yaml
+# from source:
+python validate_config.py path/to/config.yaml
+```
+
+Prints `Config is valid` or the first validation error.
+
+## The webhook service
+
+[`src/webserv.py`](../src/webserv.py) is a Flask app served by gunicorn:
+
+```bash
+gunicorn -w 2 --timeout 240 -b 0.0.0.0:80 webserv:app   # run from src/
+```
+
+Endpoints (both require the `X-Gitea-Signature` HMAC header, verified against
+`AUTH_KEY`):
+
+| Endpoint | Trigger | Purpose |
+|----------|---------|---------|
+| `POST /debrand_packages` | Gitea *push* webhook on the `rpms` namespace | Debrand the package on the pushed upstream branch. |
+| `POST /autopatch_pr_merged` | Gitea *pull request* webhook on the `autopatch` namespace | When a merged **agent-fix** PR closes, re-run debranding. |
+
+### Runtime environment variables
+
+| Variable | Used by | Meaning |
+|----------|---------|---------|
+| `AUTH_KEY` | webserv | Shared secret for Gitea webhook HMAC. **Required.** |
+| `ALLOW_NOTARIZATION` | git tools | `false` disables immudb verify/notarize (default `true`). |
+| `AGENT_ENABLED` | webserv | `true` enables the AI recovery agent on failure. |
+| `AGENT_DRY_RUN` | agent | `true` = analyze only, no branch/PR. |
+| `AGENT_IMAGE` | agent | Container image (default `localhost/autopatch-agent:latest`). |
+| `AGENT_AUTH_VOLUME` | agent | Named volume with the Claude Code OAuth session. |
+| `AGENT_TIMEOUT` | agent | Container timeout in seconds (default 600). |
+| `AGENT_LOG_PATH` | agent | Log directory (default `/var/log/autopatch`). |
+| `GITEA_TOKEN` | agent | Token used to open the fix PR via the Gitea API. |
+
+Credentials read from files: immudb/CAS at `~/.cas/credentials`; Slack token at
+`~/.almalinux-debranding-slack/token`.
+
+## Ansible deployment
+
+The [`ansible/`](../ansible) role installs dependencies, deploys the source,
+saves secrets, optionally builds the agent image, and creates the systemd
+service.
+
+### 1. Define secrets
+
+Set the following in `ansible/roles/deploy/vars/main.yml`
+
+### 2. Inventory
+
+```ini
+[deploy_servers]
+your-server-ip ansible_user=your_user ansible_ssh_private_key_file=your_key
+```
+
+### 3. Run
+
+```bash
+ansible-playbook -i inventory.ini main.yml
+```
+
+### 4. Verify
+
+```bash
+systemctl status almalinux-autopatch.service
+```
+
+The systemd unit
+([template](../ansible/roles/deploy/templates/almalinux-autopatch.service.j2))
+runs gunicorn from the deployed `src/` and injects the environment variables
+above. Agent variables are only set when `deploy_agent_enabled` is true.
+
+## AI agent container
+
+When the agent is enabled, the recovery container must be built and Claude Code
+authorized once:
+
+```bash
+# build the image
+podman build -t autopatch-agent -f agent/Containerfile .
+
+# one-time OAuth login (session persisted in the named volume)
+podman run -it \
+  -v claude-auth:/home/agent/.claude \
+  --entrypoint claude \
+  localhost/autopatch-agent:latest \
+  login
+```
+
+Full agent design, data flow, manual test runs and dry-run behavior are
+documented in [`agent/README.md`](../agent/README.md).
+
+## RPM packaging
+
+A [`Makefile`](../Makefile) builds source and binary RPMs from
+[`autopatch.spec`](../autopatch.spec):
+
+```bash
+make srpm     # source RPM
+make rpm      # binary RPM
+make clean
+```
+
+The spec produces a metapackage plus sub-packages:
+
+- `autopatch-core` — minimum install: the action engine (`actions_handler.py`),
+  the core tools (`tools/rpm.py`, `tools/tools.py`, `tools/logger.py`), and the
+  `autopatch` and `autopatch_validate_config` CLIs.
+- `autopatch` (main) — adds the git/debranding workflow (`debranding.py`,
+  `tools/git.py`, `tools/branch.py`), Slack (`tools/slack.py`), the web service
+  (`webserv.py`, `tools/webserv_tools.py`), and the `autopatch_package_patching`
+  CLI.
+
+The agent host components (`agent_handler.py`, `agent_orchestrator.py`) are
+deployed from source via Ansible and are **deliberately excluded** from the RPM
+tarball (see the `--exclude` flags in the `Makefile`).
+
+### Packaging notes
+
+- `python3-slackclient` (for Slack) is not currently in EPEL9.
+- `python3-immudb-wrapper` (for notarization) is not yet packaged; the Ansible
+  role installs it from git.
+
+## Operational notes
+
+- **Logs:** the service logs to stdout/journald; agent runs additionally write
+  per-run logs under `/var/log/autopatch/agent/` and an append-only
+  `agent_runs.jsonl`.
+- **Notifications:** success/failure and agent results are posted to the
+  `almalinux-debranding` Slack channel.
+- **Idempotency:** each run resets the AlmaLinux branch to the fresh upstream
+  import before applying the config, so re-running is safe.
+- **Skipping:** pushes to already-AlmaLinux branches (`a*`) are ignored by
+  `/debrand_packages`; packages without an `autopatch` config repo or matching
+  branch are skipped.

--- a/docs/writing-actions.md
+++ b/docs/writing-actions.md
@@ -1,0 +1,267 @@
+# Writing New Actions (Developer Guide)
+
+This guide explains how the action engine works internally and how to add a new
+action type (a new YAML key under `actions:`). All of it lives in
+[`src/actions_handler.py`](../src/actions_handler.py), with RPM-specific helpers
+in [`src/tools/rpm.py`](../src/tools/rpm.py).
+
+If you only want to *write configs*, read [configuration.md](configuration.md)
+instead.
+
+## The model: Entry + Action
+
+Every action type is a pair of classes:
+
+| Class | Base | Responsibility |
+|-------|------|----------------|
+| `…Entry` | `BaseEntry` | Validate one YAML entry's keys/types; resolve the target file. |
+| `…Action` | `BaseAction` | Hold a list of entries and `execute()` them against the package. |
+
+`ConfigReader` ties them together:
+
+```python
+class ConfigReader:
+    ACTION_MAP = {
+        "replace": ReplaceAction,
+        "delete_line": DeleteLineAction,
+        "changelog_entry": ChangelogAction,
+        "modify_release": ModifyReleaseAction,
+        "delete_files": DeleteFilesAction,
+        "add_files": AddFilesAction,
+        "run_script": RunScriptAction,
+        "add_line": AddLineAction,
+        # ← register your new action here
+    }
+```
+
+Flow when a config is applied:
+
+```
+ConfigReader(config_path)
+  ├─ _load_config()        # YAML → dict
+  ├─ _validate_config()    # top-level shape; action type ∈ ACTION_MAP
+  ├─ build GlobalParameters from parameters:
+  └─ for each action block:
+        ACTION_MAP[type](entries, config_source, global_parameters)
+            └─ BaseAction._create_entries() → [ENTRY_CLASS(...), ...]
+
+ConfigReader.apply_actions(package_path)
+  └─ for each action: action.execute(package_path)   # in order
+```
+
+## `BaseEntry` contract
+
+```python
+class MyEntry(BaseEntry):
+    ALLOWED_KEYS = {            # key -> expected type (or tuple of types)
+        "target": str,
+        "count": int,
+        "number": (str, int),   # multiple accepted types
+    }
+    REQUIRED_KEYS = {"target"}  # subset of ALLOWED_KEYS that must be present
+```
+
+`BaseEntry.__init__` runs `_validate_keys(kwargs)`, which:
+
+- rejects unknown keys (anything not in `ALLOWED_KEYS`);
+- rejects missing `REQUIRED_KEYS`;
+- type-checks every provided value against `ALLOWED_KEYS`;
+- rejects empty values for required keys (except booleans).
+
+Then it stores every kwarg as an attribute (`self.<key> = value`) and saves
+`self.global_parameters`.
+
+Two things you usually do in your Entry's `__init__`:
+
+1. **Apply defaults** for optional keys:
+   ```python
+   def __init__(self, global_parameters, **kwargs):
+       super().__init__(global_parameters, **kwargs)
+       self.count = kwargs.get("count", -1)
+   ```
+2. **Set `self.target`** — the file the action operates on. This is consumed by
+   the inherited helpers:
+   - `get_target_file_name(package_path, first=True)` — if `target == "spec"`,
+     finds the single `*.spec`; otherwise finds files matching `self.target`
+     (glob-aware, skips `tests/` dirs). Returns one path, or a list when
+     `first=False`.
+   - `get_file_name(package_path, name, first=True)` — generic recursive lookup.
+
+   If your action doesn't operate on a file, set `self.target = ""`.
+
+Add any extra validation you need and `raise ValueError`/`TypeError` with a
+clear message (see `ReplaceEntry` for the mutually-exclusive `find`/`rfind`
+pattern, or `AddFilesEntry._validate_number`).
+
+## `BaseAction` contract
+
+```python
+class MyAction(BaseAction):
+    ENTRY_CLASS = MyEntry
+
+    def execute(self, package_path: Path):
+        for entry in self.entries:
+            ...
+```
+
+- `ENTRY_CLASS` tells the base how to build entries.
+- `self.entries` — the validated entry objects.
+- `self.config_source` — `Path` to the `config.yaml`. Use
+  `self.config_source.parent / "files"` and `… / "scripts"` to reach bundled
+  files (as `AddFilesAction` and `RunScriptAction` do).
+- `self.global_parameters` — the `GlobalParameters` instance.
+- `execute(package_path)` is **the only method you must implement.** It receives
+  the path to the package working tree (the dist-git checkout).
+
+## Helpers you should reuse
+
+From `actions_handler.py`:
+
+| Helper | Use |
+|--------|-----|
+| `read_file_data(path) -> list[str]` | Read a file as a list of lines (newlines stripped). Raises on empty. |
+| `write_file_data(path, lines)` | Write a list of lines back. |
+| `process_lines(path, target, find_lines, replace_lines, count, is_regex=False)` | The shared find/replace/delete engine used by `replace` and `delete_line`. Pass `replace_lines=""` to delete. Raises `ActionNotAppliedError` if nothing changed. |
+| `ActionNotAppliedError(action_name, reason)` | Raise when your action verifies it changed nothing — this is how the engine surfaces stale configs. |
+
+From `tools/rpm.py` (when working with spec files):
+
+| Helper | Use |
+|--------|-----|
+| `apply_patch(...)` | Insert a `PatchNNN:`/`SourceNNN:` + apply directive correctly. |
+| `add_line_to_section(spec, section, location, content, subpackage)` | Insert into a spec section. |
+| `find_section_boundaries(...)`, `get_version_information(...)`, `is_release(...)`, `is_changelog(...)`, `spec_contains_autosetup/autochangelog(...)` | Spec parsing primitives. |
+
+From `tools/tools.py`:
+
+| Helper | Use |
+|--------|-----|
+| `run_command(cmd, raise_on_failure=True, cwd=None, timeout=None)` | Run a subprocess (used by `run_script`). |
+
+## Step-by-step: add a new action
+
+We'll add an `append_file` action that appends content to the end of a file.
+
+### 1. Define the Entry
+
+```python
+class AppendFileEntry(BaseEntry):
+    """Entry for the AppendFileAction."""
+    ALLOWED_KEYS = {
+        "target": str,
+        "content": str,
+    }
+    REQUIRED_KEYS = {"target", "content"}
+    # `target` is inherited and consumed by get_target_file_name();
+    # "spec" or a (glob) file path both work out of the box.
+```
+
+### 2. Define the Action
+
+```python
+class AppendFileAction(BaseAction):
+    """Append `content` to the end of the target file(s)."""
+    ENTRY_CLASS = AppendFileEntry
+
+    def execute(self, package_path: Path):
+        for entry in self.entries:
+            # first=False → support glob targets matching several files
+            for file_path in entry.get_target_file_name(package_path, first=False):
+                logger.info(f"Appending to {file_path}: {entry}")
+                data = read_file_data(file_path)
+                new_lines = entry.content.splitlines()
+                if not new_lines:
+                    raise ActionNotAppliedError(
+                        "AppendFileAction", "content is empty"
+                    )
+                data.extend(new_lines)
+                write_file_data(file_path, data)
+```
+
+### 3. Register it in `ACTION_MAP`
+
+```python
+class ConfigReader:
+    ACTION_MAP = {
+        ...
+        "add_line": AddLineAction,
+        "append_file": AppendFileAction,   # ← new
+    }
+```
+
+The YAML key (`append_file`) is exactly the `ACTION_MAP` key.
+
+### 4. Use it in a config
+
+```yaml
+actions:
+  - append_file:
+    - target: "README.md"
+      content: |
+        This package was rebuilt by AlmaLinux Autopatch.
+```
+
+### 5. Document it
+
+- Add an annotated block to [`conf_example.yaml`](../conf_example.yaml).
+- Add a section to [configuration.md](configuration.md) and, if useful for
+  config authors, to [`SKILL.md`](../SKILL.md).
+
+### 6. Add a test
+
+The suite in [`tests/test_actions.py`](../tests/test_actions.py) is fixture-driven
+(see [Testing](#testing)). Add a fixture directory and an `expected/` tree, or a
+targeted unit test for the new behavior.
+
+## Conventions & gotchas
+
+- **Fail loudly.** If an action expects to change something and doesn't, raise
+  `ActionNotAppliedError`. Silent no-ops produce subtly wrong packages.
+- **Respect spec semantics.** When editing a spec, stop at `%changelog` and skip
+  comment lines where appropriate — reuse `process_lines`/`tools_rpm` rather than
+  re-implementing.
+- **Support globs where it makes sense.** Use
+  `get_target_file_name(..., first=False)` and loop, like `ReplaceAction`.
+- **Preserve indentation** when inserting/replacing multi-line content (see
+  `_get_indent` / `_apply_indentation`).
+- **Keep the container in sync.** The AI agent validates fixes with the same
+  `autopatch_validate_config` / `autopatch` CLIs, so a new action automatically
+  works there once it's in `actions_handler.py`. If you add new runtime files,
+  update `agent/Containerfile`, `setup.py`, the `%files` list in
+  `autopatch.spec`, and the `Makefile` tarball includes.
+- **Use the shared logger** (`from tools.logger import logger`) — note the
+  dual-import pattern (`autopatch.*` vs `*`) used throughout the codebase so the
+  code runs both installed and from source.
+
+## Testing
+
+```bash
+# install dev deps (pytest, freezegun, pyyaml, ...)
+python -m pytest tests/ -v
+
+# only the action engine
+python -m pytest tests/test_actions.py -v
+```
+
+`tests/test_actions.py` discovers fixture cases under `tests/configs/<name>/`:
+
+```
+tests/configs/<name>/
+├── <name>.spec              # input spec
+├── autopatch/<name>.yaml    # the config to apply
+├── autopatch/files/         # optional: files for add_files
+└── expected/                # expected output tree (compared after applying)
+```
+
+For each case it copies the inputs into a results dir, runs `ConfigReader` +
+`apply_actions`, and diffs the result against `expected/`. To add a case, create
+those files; no code change is needed. Other suites:
+
+| File | Covers |
+|------|--------|
+| `tests/test_parser.py` | config parsing/validation |
+| `tests/test_git.py`, `tests/test_tools.py`, `tests/test_slack.py` | helpers |
+| `tests/test_agent*.py` | AI recovery pipeline |
+
+Run `autopatch_validate_config` on real configs as a fast sanity check before
+running the full workflow.

--- a/src/actions_handler.py
+++ b/src/actions_handler.py
@@ -31,7 +31,7 @@ class GlobalParameters:
     pre_clean: bool
     ignore_version_macros: bool
     ignore_release_macros: bool
-    rhel_version: str
+    el_version: str
 
     def __init__(self, parameters: dict = {}):
         self.insert_almalinux_line = parameters.get("insert_almalinux_line", True)
@@ -40,7 +40,10 @@ class GlobalParameters:
         self.ignore_version_macros = parameters.get("ignore_version_macros", False)
         self.ignore_release_macros = parameters.get("ignore_release_macros", False)
         self.tag_prefix = parameters.get("tag_prefix", "")
-        self.rhel_version = parameters.get("rhel_version", "8")
+        # "rhel_version" is kept as a legacy alias for "el_version".
+        self.el_version = parameters.get(
+            "el_version", parameters.get("rhel_version", "8")
+        )
 
 class ActionNotAppliedError(Exception):
     """
@@ -633,7 +636,7 @@ class ChangelogAction(BaseAction):
                     True,
                 )
             parsed_data = tools_rpm.prepare_spec_file_data_with_rpmspec(
-                spec_info, file_path, self.global_parameters.rhel_version
+                spec_info, file_path, self.global_parameters.el_version
             )
             epoch, parsed_version, parsed_release = tools_rpm.get_version_information(
                 parsed_data,
@@ -863,13 +866,13 @@ class ConfigReader:
         "add_line": AddLineAction,
     }
 
-    def __init__(self, config_source, rhel_version: str = "8"):
+    def __init__(self, config_source, el_version: str = "8"):
         if isinstance(config_source, (str, bytes, Path)):
             self.config_source = Path(config_source)
         else:
             self.config_source = config_source
         self.actions = []
-        self.rhel_version = rhel_version
+        self.el_version = el_version
         self.global_parameters = GlobalParameters()
         self._read_config()
 
@@ -907,7 +910,10 @@ class ConfigReader:
 
         actions_data = config_data.get("actions")
         parameters = config_data.get("parameters", {})
-        parameters.setdefault("rhel_version", self.rhel_version)
+        # Backwards compat: accept the legacy "rhel_version" key as "el_version".
+        if "el_version" not in parameters and "rhel_version" in parameters:
+            parameters["el_version"] = parameters.pop("rhel_version")
+        parameters.setdefault("el_version", self.el_version)
         self.global_parameters = GlobalParameters(parameters)
 
         for action_data in actions_data:

--- a/src/debranding.py
+++ b/src/debranding.py
@@ -5,13 +5,13 @@ try:
     from autopatch.tools.logger import logger
     from autopatch.actions_handler import ConfigReader
     from autopatch.tools.git import GitRepository, GitAlmaLinux, DirectoryManager
-    from autopatch.tools.rpm import extract_rhel_version
+    from autopatch.tools.rpm import extract_el_version
     from autopatch.tools.branch import resolve_config_branch, strip_beta
 except ImportError:
     from tools.logger import logger
     from actions_handler import ConfigReader
     from tools.git import GitRepository, GitAlmaLinux, DirectoryManager
-    from tools.rpm import extract_rhel_version
+    from tools.rpm import extract_el_version
     from tools.branch import resolve_config_branch, strip_beta
 
 BRANCH_NOT_MODIFIED = "Branch is not modified"
@@ -58,8 +58,8 @@ def apply_modifications(
         config_repo.checkout_branch(config_branch)
         config_repo.pull()
 
-    rhel_version = extract_rhel_version(branch)
-    logger.info(f"Detected RHEL version: {rhel_version} (from branch '{branch}')")
+    el_version = extract_el_version(branch)
+    logger.info(f"Detected EL version: {el_version} (from branch '{branch}')")
 
     config_files = get_config_files(autopatch_working_dir, package)
     if not config_files:
@@ -72,7 +72,7 @@ def apply_modifications(
 
         config = ConfigReader(
             f"{autopatch_working_dir}/{package}/{config_file}",
-            rhel_version=rhel_version
+            el_version=el_version
         )
         if config.global_parameters.custom_target_branch:
             _al_branch = config.global_parameters.custom_target_branch

--- a/src/tools/rpm.py
+++ b/src/tools/rpm.py
@@ -12,9 +12,9 @@ except ImportError:
     from tools.logger import logger
     from tools.tools import run_command
 
-def extract_rhel_version(branch: str) -> str:
+def extract_el_version(branch: str) -> str:
     """
-    Extract the RHEL version number from a branch name.
+    Extract the Enterprise Linux (EL) version number from a branch name.
 
     Supports branch formats like: c8, c9, c10, c8s, c10s, c8-beta,
     a8, a9, a10, a10s, etc.
@@ -27,7 +27,7 @@ def extract_rhel_version(branch: str) -> str:
     Returns
     -------
     str
-        RHEL version number (e.g. "8", "9", "10").
+        EL version number (e.g. "8", "9", "10").
 
     Raises
     ------
@@ -38,19 +38,19 @@ def extract_rhel_version(branch: str) -> str:
     if match:
         return match.group(1)
     raise ValueError(
-        f"Cannot extract RHEL version from branch '{branch}'. "
+        f"Cannot extract EL version from branch '{branch}'. "
         f"Expected format: c8, c9, c10, a8, a9, a10, etc."
     )
 
 
-def get_rpmspec_definitions(rhel_version: str = "8") -> dict:
+def get_rpmspec_definitions(el_version: str = "8") -> dict:
     """
-    Get rpmspec macro definitions for the given RHEL version.
+    Get rpmspec macro definitions for the given Enterprise Linux version.
 
     Parameters
     ----------
-    rhel_version : str
-        RHEL major version number (e.g. "8", "9", "10").
+    el_version : str
+        Enterprise Linux major version number (e.g. "8", "9", "10").
 
     Returns
     -------
@@ -64,7 +64,7 @@ def get_rpmspec_definitions(rhel_version: str = "8") -> dict:
         "gometa": "%{nil}",
         "efi_has_alt_arch": "0",
         "dist": "%{nil}",
-        "rhel": rhel_version,
+        "rhel": el_version,
     }
 
 AUTORELEASE_FINAL_LINE = '}%{?-e:.%{-e*}}%{?-s:.%{-s*}}%{!?-n:%{?dist}}'
@@ -127,7 +127,7 @@ def spec_contains_autosetup(spec: list[str]) -> bool:
 def prepare_spec_file_data_with_rpmspec(
     spec: list[str],
     spec_file_path,
-    rhel_version: str = "8"
+    el_version: str = "8"
 ) -> list[str]:
     """
     Read a spec file with updated release attribute using rpmspec utility.
@@ -137,8 +137,8 @@ def prepare_spec_file_data_with_rpmspec(
         all changelog_info of spec-file.
     spec_file_path : str or Path
         path to the spec file.
-    rhel_version : str
-        RHEL major version number (e.g. "8", "9", "10").
+    el_version : str
+        Enterprise Linux major version number (e.g. "8", "9", "10").
     Returns
     -------
     list of str
@@ -151,7 +151,7 @@ def prepare_spec_file_data_with_rpmspec(
 
         definitions = ["--define", f"_sourcedir {source_path}"]
 
-        for key, value in get_rpmspec_definitions(rhel_version).items():
+        for key, value in get_rpmspec_definitions(el_version).items():
             definitions.extend(["--define", f"{key} {value}"])
 
         with NamedTemporaryFile("w", delete=False) as tmp_file:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -64,6 +64,81 @@ actions:
     assert config_reader.global_parameters.tag_prefix == ""
 
 
+def test_global_parameters_el_version_default():
+    params = GlobalParameters()
+    assert params.el_version == "8"
+
+def test_global_parameters_el_version_custom():
+    params = GlobalParameters({"el_version": "9"})
+    assert params.el_version == "9"
+
+def test_global_parameters_el_version_legacy_alias():
+    # The legacy "rhel_version" key must still be accepted as an alias.
+    params = GlobalParameters({"rhel_version": "9"})
+    assert params.el_version == "9"
+
+def test_global_parameters_el_version_prefers_new_key():
+    # When both keys are present, "el_version" wins over the legacy alias.
+    params = GlobalParameters({"el_version": "10", "rhel_version": "9"})
+    assert params.el_version == "10"
+
+def test_global_parameters_el_version_from_config(create_temp_config_file):
+    config_string = """
+parameters:
+  el_version: "10"
+actions:
+  - replace:
+      - target: "spec"
+        find: "RHEL"
+        replace: "AlmaLinux"
+"""
+    temp_config = create_temp_config_file(config_string)
+    config_reader = ConfigReader(temp_config)
+    assert config_reader.global_parameters.el_version == "10"
+
+def test_global_parameters_el_version_legacy_from_config(create_temp_config_file):
+    config_string = """
+parameters:
+  rhel_version: "10"
+actions:
+  - replace:
+      - target: "spec"
+        find: "RHEL"
+        replace: "AlmaLinux"
+"""
+    temp_config = create_temp_config_file(config_string)
+    config_reader = ConfigReader(temp_config)
+    assert config_reader.global_parameters.el_version == "10"
+
+def test_global_parameters_el_version_uses_constructor_default(create_temp_config_file):
+    # When the config omits the key, the value passed to ConfigReader is used.
+    config_string = """
+actions:
+  - replace:
+      - target: "spec"
+        find: "RHEL"
+        replace: "AlmaLinux"
+"""
+    temp_config = create_temp_config_file(config_string)
+    config_reader = ConfigReader(temp_config, el_version="9")
+    assert config_reader.global_parameters.el_version == "9"
+
+def test_global_parameters_el_version_config_overrides_constructor(create_temp_config_file):
+    # An explicit key in the config overrides the constructor default.
+    config_string = """
+parameters:
+  el_version: "10"
+actions:
+  - replace:
+      - target: "spec"
+        find: "RHEL"
+        replace: "AlmaLinux"
+"""
+    temp_config = create_temp_config_file(config_string)
+    config_reader = ConfigReader(temp_config, el_version="9")
+    assert config_reader.global_parameters.el_version == "10"
+
+
 def test_add_files_entry_valid():
     entry = AddFilesEntry(global_parameters=GlobalParameters(), type="source", name="example.tar.gz", number=1)
     assert entry.type == "source"

--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -1,0 +1,49 @@
+import pytest
+
+from src.tools.rpm import extract_el_version, get_rpmspec_definitions
+
+
+@pytest.mark.parametrize(
+    "branch, expected",
+    [
+        ("c8", "8"),
+        ("c9", "9"),
+        ("c10", "10"),
+        ("c8s", "8"),
+        ("c10s", "10"),
+        ("c8-beta", "8"),
+        ("a8", "8"),
+        ("a9", "9"),
+        ("a10", "10"),
+        ("a10s", "10"),
+        ("a10-beta", "10"),
+    ],
+)
+def test_extract_el_version_valid(branch, expected):
+    assert extract_el_version(branch) == expected
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "main",
+        "rawhide",
+        "fedora",
+        "",
+        "b8",
+    ],
+)
+def test_extract_el_version_invalid(branch):
+    with pytest.raises(ValueError, match="Cannot extract EL version"):
+        extract_el_version(branch)
+
+
+def test_get_rpmspec_definitions_default():
+    # The EL version maps onto the real RPM "%{?rhel}" macro.
+    definitions = get_rpmspec_definitions()
+    assert definitions["rhel"] == "8"
+
+
+def test_get_rpmspec_definitions_custom():
+    definitions = get_rpmspec_definitions("10")
+    assert definitions["rhel"] == "10"


### PR DESCRIPTION
## Summary
- Expand the docs into a foundational set: new `docs/configuration.md` (full `config.yaml` reference), `docs/deployment.md` (CLI/webhook/Ansible/agent), and `docs/writing-actions.md` (developer guide for adding action types); rewritten `README.md` as an index.
- Remove CentOS/Red Hat/RHEL references across the documentation in favour of vendor-neutral wording ("upstream", "Enterprise Linux"), keeping factual branch identifiers (`c8`/`c9`) intact.
- Rename the `rhel_version` parameter and its helpers (`extract_rhel_version` → `extract_el_version`, `GlobalParameters.el_version`, `ConfigReader(el_version=...)`) to `el_version`, while still accepting the legacy `rhel_version` key as an alias so existing configs keep working.
- Add tests for the new `el_version` key, the legacy `rhel_version` alias, and branch-to-version extraction.

## Test plan
- [ ] `PYTHONPATH=src python -m pytest tests/test_parser.py tests/test_rpm.py -q` passes (covers `el_version` default/custom/legacy-alias/precedence and `extract_el_version`).
- [ ] `PYTHONPATH=src python -m pytest tests/test_actions.py -q` — fixture suite still green (8 pre-existing failures only occur where the local `rpmspec` rejects obsolete `%patchNNN` syntax; unrelated to this change).
- [ ] A config using `parameters: { rhel_version: "9" }` still resolves to EL 9 (backwards compat).
- [ ] A config using `parameters: { el_version: "9" }` resolves to EL 9.
- [ ] Review rendered docs: relative links resolve and no CentOS/Red Hat/RHEL references remain (except the documented legacy `rhel_version` alias).